### PR TITLE
Fixed typo in 'Get your spotify API credentials' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Documentation for Spotifynd
 
 Before running the project locally, you have to - 
 ## Get your spotify API credentials  
-- Log on to [Sporify Dashboard](https://developer.spotify.com/dashboard/)
+- Log on to [Spotify Dashboard](https://developer.spotify.com/dashboard/)
 - Create a new app. This should generate CLIENT_ID and CLIENT_SECRET
 - Copy and paste these into your local copy of [creds.py](https://github.com/absotone/spotifynd/blob/main/creds.py)
 


### PR DESCRIPTION
I am so sorry this took so long. It was my own keychain access app that was causing issues😥.